### PR TITLE
Odometry handle weird movement and pseudocode for arm

### DIFF
--- a/include/aon/competition/autonomous-routines.hpp
+++ b/include/aon/competition/autonomous-routines.hpp
@@ -338,6 +338,7 @@ void MoveTurnPID(PID pid = turnPID, double angle = 90, const double &MAX_REVS = 
   angle = abs(angle); // Setting the magnitude to positive
   pid.Reset();
   gyroscope.tare(); // .tare() or .reset(true) depending on the time issue
+  aon::odometry::gyro_data.prevDegrees = 0;
   const double startAngle = gyroscope.get_heading(); // Angle relative to the start
   
   double timeLimit = getTimetoTurnDeg(angle);

--- a/include/aon/competition/autonomous-routines.hpp
+++ b/include/aon/competition/autonomous-routines.hpp
@@ -298,7 +298,7 @@ double calculateTurn(Vector target, Vector current) {
  * \param pid The PID used for the driving
  * \param dist The distance to be moved in \b inches
  */
-void MoveDrivePID(PID pid = drivePID, double dist = TILE_WIDTH, const double MAX_REVS = 100.0) {
+void MoveDrivePID(PID pid = drivePID, double dist = TILE_WIDTH, const double MAX_REVS = 30.0) {
   const int sign = dist / abs(dist); // Getting the direction of the movement
   dist = abs(dist); // Setting the magnitude to positive
 
@@ -343,6 +343,7 @@ void MoveTurnPID(PID pid = turnPID, double angle = 90, const double MAX_REVS = 5
   angle = abs(angle); // Setting the magnitude to positive
   pid.Reset();
   gyroscope.tare(); // .tare() or .reset(true) depending on the time issue
+  aon::odometry::gyro_data.prevDegrees = 0; // Restart gyro data everytime gyro is restart
   const double startAngle = gyroscope.get_heading(); // Angle relative to the start
 
   if(sign == -1) { angle = 360.0 - angle + CLOCKWISE_ROTATION_DEGREES_OFFSET; }
@@ -367,9 +368,12 @@ void MoveTurnPID(PID pid = turnPID, double angle = 90, const double MAX_REVS = 5
     // Taking clockwise rotation as positive (to change this just flip the negative on the sign below)
     driveLeft.moveVelocity(sign * std::clamp(output * (int)driveLeft.getGearing(), -MAX_REVS, MAX_REVS));
     driveRight.moveVelocity(-sign * std::clamp(output * (int)driveRight.getGearing(), -MAX_REVS, MAX_REVS));
-
+    
     pros::delay(10);
   }
+  std::cout << "Ends rotation function.\nlkfpaosurfkqnadipfuhasoidnf;ipasdhfo9uasd\n;asohfcpoiaiw coiphawiuehfipuawhifnd\n;aliowhyefiuanijdfchasiuhefcipuawhiufasdldifyqipenc\naijhfdpianoifphawoiwpenfipawhc9pawe\nolahyfpio awiupghecijawneicuhaslijefch9p;a9enc\n;aoiweyrfa;wcjniahef9phacn\npaiuisdhcaiwchiaewrbfuhawbce8ohawibfpiaw\nalishjefiuauwencilasgfciawboliecbasilfh\nlifhaelkncias";
+
+  // aon::odometry::UpdateTurn(gyroscope.get_heading());
 
   driveLeft.moveVelocity(0);
   driveRight.moveVelocity(0);

--- a/include/aon/competition/operator-control.hpp
+++ b/include/aon/competition/operator-control.hpp
@@ -115,8 +115,8 @@ inline void _OpControlManes() {
     indexer.set_value(false);
   }
 
-  std::cout << "Motor encoder: " << arm.getPosition() << "\n";
-
+  
+  // Limit how much down you go with the arm
   if (main_controller.get_digital(DIGITAL_L1) && arm.getPosition() > 0) {
     arm.moveVelocity(-ARM_VELOCITY);
   } else if (main_controller.get_digital(DIGITAL_L2)) {
@@ -125,6 +125,8 @@ inline void _OpControlManes() {
     arm.moveVelocity(0);
   }
 
+  // Add combination to lower the arm to grab ring
+  
 
 #else
   //////////// DRIVE ////////////

--- a/include/aon/competition/operator-control.hpp
+++ b/include/aon/competition/operator-control.hpp
@@ -18,68 +18,70 @@
  *
  */
 namespace aon::operator_control {
+  
+  // ============================================================================
+  //    _  _     _                 ___             _   _
+  //   | || |___| |_ __  ___ _ _  | __|  _ _ _  __| |_(_)___ _ _  ___
+  //   | __ / -_) | '_ \/ -_) '_| | _| || | ' \/ _|  _| / _ \ ' \(_-<
+  //   |_||_\___|_| .__/\___|_|   |_| \_,_|_||_\__|\__|_\___/_||_/__/
+  //              |_|
+  // ============================================================================
+  
+  /**
+   * \brief Scales analog joystick input for easier control.
+   *
+   * \details Fine joystick control can be difficult, specially for tasks like
+   *     rotating. After researching the forums I found that teams scale their
+   *     joystick inputs using an exponential function of sorts. This makes small
+   *     inputs produce a smaller output and bigger inputs increase speed, so fine
+   *     movements can be done without as much of a hassle.
+   *
+   * \param x The controller's user input between -1 and 1
+   * \param t Decrease in sensitivity
+   *
+   * <a href="https://www.desmos.com/calculator/uhjyivyj4r">Demonstration of
+   * scaling function in Desmos.</a>
+   *
+   * \return double
+   *
+   * \warning Make sure that the input x is between -1 and 1!!!
+   */
+  inline double AnalogInputScaling(const double x, const double t) {
+    const double z = 127.0 * x;
+    const double a = ::std::exp(-::std::fabs(t) / 10.0);
+    const double b = ::std::exp((::std::fabs(z) - 127.0) / 10.0);
+    
+    return (a + b * (1 - a)) * z / 127.0;
+  }
+  
+  /**
+   * \brief Makes the rail go slightly back
+   */
+  void kickBackRail(){
+    rail.moveVelocity(-100);
+    pros::delay(150);
+    rail.moveVelocity(0);
+  }
 
-// ============================================================================
-//    _  _     _                 ___             _   _
-//   | || |___| |_ __  ___ _ _  | __|  _ _ _  __| |_(_)___ _ _  ___
-//   | __ / -_) | '_ \/ -_) '_| | _| || | ' \/ _|  _| / _ \ ' \(_-<
-//   |_||_\___|_| .__/\___|_|   |_| \_,_|_||_\__|\__|_\___/_||_/__/
-//              |_|
-// ============================================================================
-
-/**
- * \brief Scales analog joystick input for easier control.
- *
- * \details Fine joystick control can be difficult, specially for tasks like
- *     rotating. After researching the forums I found that teams scale their
- *     joystick inputs using an exponential function of sorts. This makes small
- *     inputs produce a smaller output and bigger inputs increase speed, so fine
- *     movements can be done without as much of a hassle.
- *
- * \param x The controller's user input between -1 and 1
- * \param t Decrease in sensitivity
- *
- * <a href="https://www.desmos.com/calculator/uhjyivyj4r">Demonstration of
- * scaling function in Desmos.</a>
- *
- * \return double
- *
- * \warning Make sure that the input x is between -1 and 1!!!
- */
-inline double AnalogInputScaling(const double x, const double t) {
-  const double z = 127.0 * x;
-  const double a = ::std::exp(-::std::fabs(t) / 10.0);
-  const double b = ::std::exp((::std::fabs(z) - 127.0) / 10.0);
-
-  return (a + b * (1 - a)) * z / 127.0;
-}
-
-/**
- * \brief Makes the rail go slightly back
- */
-void kickBackRail(){
-  rail.moveVelocity(-100);
-  pros::delay(150);
-  rail.moveVelocity(0);
-}
-
-// ============================================================================
-//    ___      _
-//   |   \ _ _(_)_ _____ _ _ ___
-//   | |) | '_| \ V / -_) '_(_-<
-//   |___/|_| |_|\_/\___|_| /__/
-//
-// ============================================================================
-
-/// Enrique's Operator Control configuration
-inline void _OpControlEnrique() {
-#if USING_15_INCH_ROBOT
-#endif
-}
-
-/// Manes's Operator Control configuration
-inline void _OpControlManes() {
-#if USING_15_INCH_ROBOT
+  bool retreat = false;
+  
+  // ============================================================================
+  //    ___      _
+  //   |   \ _ _(_)_ _____ _ _ ___
+  //   | |) | '_| \ V / -_) '_(_-<
+  //   |___/|_| |_|\_/\___|_| /__/
+  //
+  // ============================================================================
+  
+  /// Enrique's Operator Control configuration
+  inline void _OpControlEnrique() {
+    #if USING_15_INCH_ROBOT
+    #endif
+  }
+  
+  /// Manes's Operator Control configuration
+  inline void _OpControlManes() {
+    #if USING_15_INCH_ROBOT
 
   //////////// DRIVE ////////////
   const double vertical = AnalogInputScaling(main_controller.get_analog(pros::E_CONTROLLER_ANALOG_LEFT_Y) / 127.0, SENSITIVITY_DECREASE);
@@ -112,13 +114,16 @@ inline void _OpControlManes() {
     moveIndexer(toggle(indexerOut));
   }
 
-  if (main_controller.get_digital(DIGITAL_L1)) {
-    arm.moveVelocity(INTAKE_VELOCITY);
+  std::cout << "Motor encoder: " << arm.getPosition() << "\n";
+
+  if (main_controller.get_digital(DIGITAL_L1) && arm.getPosition() > 0) {
+    arm.moveVelocity(-ARM_VELOCITY);
   } else if (main_controller.get_digital(DIGITAL_L2)) {
-    arm.moveVelocity(-INTAKE_VELOCITY);
+    arm.moveVelocity(ARM_VELOCITY);
   } else {
     arm.moveVelocity(0);
   }
+
 
 #else
   //////////// DRIVE ////////////

--- a/include/aon/constants.hpp
+++ b/include/aon/constants.hpp
@@ -14,7 +14,7 @@
 
 // NOT using 15 inch robot = Using 18 inch robot
 #define USING_15_INCH_ROBOT true
-#define TESTING_AUTONOMOUS false
+#define TESTING_AUTONOMOUS true
 #define COLOR RED
 
 #if USING_15_INCH_ROBOT
@@ -22,13 +22,13 @@
 #define SENSITIVITY_DECREASE 30 // 20 works good, currently undergoing testing
 #define DRIVE_WHEEL_DIAMETER 3.25
 #define TRACKING_WHEEL_DIAMETER 1.959
-#define DISTANCE_LEFT_TRACKING_WHEEL_CENTER 5.650
-#define DISTANCE_RIGHT_TRACKING_WHEEL_CENTER 5.650
+#define DISTANCE_LEFT_TRACKING_WHEEL_CENTER 1.572
+#define DISTANCE_RIGHT_TRACKING_WHEEL_CENTER 1.572
 #define DISTANCE_BACK_TRACKING_WHEEL_CENTER 5.500
 #define GYRO_ENABLED true
-#define GYRO_CONFIDENCE 1
-#define GYRO_FILTER_LENGTH 1
-#define ENCODER_CONFIDENCE 1 - GYRO_CONFIDENCE
+#define GYRO_CONFIDENCE 1.0
+#define GYRO_FILTER_LENGTH 0.9
+#define ENCODER_CONFIDENCE 0.1
 #define OFFSET_X_ENCODER_MID 3.250
 
 #define DRIVE_WIDTH 12.478 //distance between front wheels
@@ -55,6 +55,7 @@
 
 #define MAX_SPEED DRIVE_WHEEL_DIAMETER * M_PI * (int)driveFull.getGearing() / 60
 #define INTAKE_VELOCITY (int)intake.getGearing()
+#define ARM_VELOCITY (int)arm.getGearing()
 
 
 #else

--- a/include/aon/globals.hpp
+++ b/include/aon/globals.hpp
@@ -9,26 +9,29 @@
 
 #if USING_15_INCH_ROBOT
 // Motor groups for drivetrain
-okapi::MotorGroup driveLeft = okapi::MotorGroup({-1});
-okapi::MotorGroup driveRight = okapi::MotorGroup({16});
-okapi::MotorGroup driveFull = okapi::MotorGroup({16, -1});
+okapi::MotorGroup driveLeft = okapi::MotorGroup({-20, 19, -18});
+okapi::MotorGroup driveRight = okapi::MotorGroup({9, -8, 7});
+okapi::MotorGroup driveFull = okapi::MotorGroup({-20, 19, -18, 9, -8, 7});
 // okapi::MotorGroup driveLeft = okapi::MotorGroup({18});
 // okapi::MotorGroup driveRight = okapi::MotorGroup({-16});
 // okapi::MotorGroup driveFull = okapi::MotorGroup({-18, 16});
 
 
 
-okapi::MotorGroup intake = okapi::MotorGroup({-13, -14});
-okapi::MotorGroup rail = okapi::MotorGroup({-13});
-okapi::Motor gate = okapi::Motor(-14);
+okapi::MotorGroup intake = okapi::MotorGroup({-16, 17});
+okapi::MotorGroup rail = okapi::MotorGroup({17});
+okapi::Motor gate = okapi::Motor(-16);
 
-okapi::Motor arm = okapi::Motor(10);
+okapi::Motor arm = okapi::Motor(-11);
 
-okapi::Motor indexer = okapi::Motor(7);
+okapi::Motor indexer = okapi::Motor('A');
 
 //odometry
-pros::Rotation encoderMid(12, true);
-pros::Rotation encoderBack(11, false);
+// pros::Rotation encoderMid(12, true);
+// pros::Rotation encoderBack(11, false);
+
+pros::Rotation encoderRight(4, true);
+pros::Rotation encoderLeft(3, false);
 
 // Turret
 okapi::Motor turret = okapi::Motor({20});
@@ -62,7 +65,7 @@ bool conveyor_auto = true;
 int state = 0; // for railing
 
 #if GYRO_ENABLED
-pros::Imu gyroscope(15);
+pros::Imu gyroscope(5);
 #endif
 
 #else
@@ -168,10 +171,21 @@ inline void ConfigureMotors() {
   intake.setEncoderUnits(okapi::AbstractMotor::encoderUnits::degrees);
   intake.tarePosition();
 
-  arm.setBrakeMode(okapi::AbstractMotor::brakeMode::brake);
+  // arm.setBrakeMode(okapi::AbstractMotor::brakeMode::brake);
+  // arm.setGearing(okapi::AbstractMotor::gearset::red);
+  // arm.setEncoderUnits(okapi::AbstractMotor::encoderUnits::degrees);
+  // arm.tarePosition();
+  
+  // while(arm.getPosition() < 100) {
+  //   arm.moveVelocity(ARM_VELOCITY);
+  // }
+  // arm.moveVelocity(0);
+  
+  arm.setBrakeMode(okapi::AbstractMotor::brakeMode::hold);
   arm.setGearing(okapi::AbstractMotor::gearset::red);
   arm.setEncoderUnits(okapi::AbstractMotor::encoderUnits::degrees);
   arm.tarePosition();
+
 
   indexer.setBrakeMode(okapi::AbstractMotor::brakeMode::brake);
   indexer.setGearing(okapi::AbstractMotor::gearset::green);

--- a/include/aon/globals.hpp
+++ b/include/aon/globals.hpp
@@ -177,20 +177,18 @@ inline void ConfigureMotors(const bool opcontrol = true) {
   intake.setEncoderUnits(okapi::AbstractMotor::encoderUnits::degrees);
   intake.tarePosition();
 
-  // arm.setBrakeMode(okapi::AbstractMotor::brakeMode::brake);
-  // arm.setGearing(okapi::AbstractMotor::gearset::red);
-  // arm.setEncoderUnits(okapi::AbstractMotor::encoderUnits::degrees);
-  // arm.tarePosition();
-  
-  // while(arm.getPosition() < 100) {
-  //   arm.moveVelocity(ARM_VELOCITY);
-  // }
-  // arm.moveVelocity(0);
-  
-  arm.setBrakeMode(okapi::AbstractMotor::brakeMode::hold);
-  arm.setGearing(okapi::AbstractMotor::gearset::red);
+  // ARM HAVE TO BE IN HIS NATURAL FORM, CLOSE TO THE ROBOT
+  // Elevate arm as default
+  arm.setBrakeMode(okapi::AbstractMotor::brakeMode::brake);
   arm.setEncoderUnits(okapi::AbstractMotor::encoderUnits::degrees);
   arm.tarePosition();
+  
+  while(arm.getPosition() < 100) {
+    arm.moveVelocity(ARM_VELOCITY);
+  }
+  arm.moveVelocity(0);
+  
+  arm.setBrakeMode(okapi::AbstractMotor::brakeMode::hold);
 
   turret.setBrakeMode(okapi::AbstractMotor::brakeMode::brake);
   turret.setGearing(okapi::AbstractMotor::gearset::green);

--- a/include/aon/sensing/odometry.hpp
+++ b/include/aon/sensing/odometry.hpp
@@ -565,34 +565,26 @@ void Update() {
 
   // If we are rotating
   if (std::abs(deltaTheta) > 0.01) {
-    // Calculate the radius of rotation for each wheel
     if ((encoderLeft_data.deltaDistance * encoderRight_data.deltaDistance) <= 0) {
       // Turning in its own axis
-      std::cout << "Turning in own axis, No movement. Update angle.\n";
       deltaDlocal.SetPosition(0.0, 0.0);
     }
     else {
-      std::cout << "Arc movement\n";
       double radiusLeft;
       double radiusRight;
+      // Calculate the radius of rotation for each wheel
   
-      // CHANGE DELTA DEPENDING OF WHAT IS POSITIVE
       double sign = (deltaTheta > 0) ? 1 : -1;
       radiusLeft  = (encoderLeft_data.deltaDistance / deltaTheta)  - sign * DISTANCE_LEFT_TRACKING_WHEEL_CENTER;
       radiusRight = (encoderRight_data.deltaDistance / deltaTheta) + sign * DISTANCE_RIGHT_TRACKING_WHEEL_CENTER;
-      std::cout << "Radius: " << radiusLeft << ", " << radiusRight << "\n\n";
 
       double averageR = (encoderLeft_data.deltaDistance + encoderRight_data.deltaDistance) / (2.0 * deltaTheta);
   
-      // Calculate deltaX and deltaY during turning (robot moves in circular arcs)
-      // deltaDlocal.SetY(2.0 * std::sin(deltaTheta / 2.0) * radiusRight);
-      // deltaDlocal.SetX(2.0 * std::sin(deltaTheta / 2.0) * radiusLeft);
       deltaDlocal.SetPosition(averageR * std::sin(deltaTheta), averageR * (1 - std::cos(deltaTheta)));
     }
   }
   else {
     // If the robot is moving straight forward or backward, average encoder values for distance
-    std::cout << "There is no turning\n";
     double deltaD = (encoderLeft_data.deltaDistance + encoderRight_data.deltaDistance) / 2.0;
     deltaDlocal.SetPosition(deltaD, 0);
   } 


### PR DESCRIPTION
Odometry can now handle weird movement using arcs. And pseudocode for arm, fails because the arms need to be close to the robot, like at his natural position, then it elevates so it doesnt get involved with the mobile target reload. 

It fails at the inicialization, the encoders nor gyro works. I change it to 0 to test but it would be bad at the competition if we dont fix that, encoders are random and get_heading from gyro its infinite. Verify and change that. Also, if we are using gps to update odometry, you have to reset all the odometry for the data to be correctly save.